### PR TITLE
Speed up downloads

### DIFF
--- a/data/data_down.sh
+++ b/data/data_down.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-FETCH_CMD="rsync -av --progress"
+FETCH_CMD="rsync -avz --progress"
 DATA_URL="lsst-rsync.ncsa.illinois.edu::sim/sims_skybrightness_pre"
 
 usage() {

--- a/data/data_up.sh
+++ b/data/data_up.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Copy data up to NCSA
-rsync -av --progress healpix/*.npz* lsst-dev01.ncsa.illinois.edu:"/datasets/public_html/sim-data/sims_skybrightness_pre/healpix/"
-rsync -av --progress healpix/*.npy* lsst-dev01.ncsa.illinois.edu:"/datasets/public_html/sim-data/sims_skybrightness_pre/healpix/"
-rsync -av --progress opsimFields/*.npz lsst-dev01.ncsa.illinois.edu:"/datasets/public_html/sim-data/sims_skybrightness_pre/opsimFields/"
-rsync -av --progress opsimFields/*.npy lsst-dev01.ncsa.illinois.edu:"/datasets/public_html/sim-data/sims_skybrightness_pre/opsimFields/"
-rsync -av --progress percentile_m5_maps.npz lsst-dev01.ncsa.illinois.edu:"/datasets/public_html/sim-data/sims_skybrightness_pre/"
+rsync -avz --progress healpix/*.npz* lsst-dev01.ncsa.illinois.edu:"/datasets/public_html/sim-data/sims_skybrightness_pre/healpix/"
+rsync -avz --progress healpix/*.npy* lsst-dev01.ncsa.illinois.edu:"/datasets/public_html/sim-data/sims_skybrightness_pre/healpix/"
+rsync -avz --progress opsimFields/*.npz lsst-dev01.ncsa.illinois.edu:"/datasets/public_html/sim-data/sims_skybrightness_pre/opsimFields/"
+rsync -avz --progress opsimFields/*.npy lsst-dev01.ncsa.illinois.edu:"/datasets/public_html/sim-data/sims_skybrightness_pre/opsimFields/"
+rsync -avz --progress percentile_m5_maps.npz lsst-dev01.ncsa.illinois.edu:"/datasets/public_html/sim-data/sims_skybrightness_pre/"


### PR DESCRIPTION
I found that adding a `-z` flag to the rsync transfers speeds up the downloads (of *.npy files) considerably. I also added a `-z` flag to the upload script, but have not checked anything there.